### PR TITLE
Crossfade Photospheres

### DIFF
--- a/photosphere/PanoViewController.swift
+++ b/photosphere/PanoViewController.swift
@@ -257,7 +257,7 @@ class PanoViewController: UIViewController {
         if curIdx != curPanoIdx {
             var activeView: GMSPanoramaView!
             var otherView: GMSPanoramaView!
-            if panoView.alpha < 1 {
+            if panoView.alpha <= panoView2.alpha {
                 activeView = panoView2
                 otherView = panoView
             } else {


### PR DESCRIPTION
Achieved a crossfade effect when transitioning between historical photospheres. This is done by maintaining two instances of GMSPanoramaViewer, keeping one at `alpha = 0` and the other at `alpha = 1`. Whenever we transition to a new photosphere, the invisible panorama viewer loads the new photosphere and fades in while the currently visible one fades out.
